### PR TITLE
Added Moped::BSON::Binary field type

### DIFF
--- a/en/mongoid/docs/documents.html
+++ b/en/mongoid/docs/documents.html
@@ -177,6 +177,7 @@
       <li><code>Hash</code></li>
       <li><code>Integer</code></li>
       <li><code>Moped::BSON::ObjectId</code></li>
+      <li><code>Moped::BSON::Binary</code></li>
       <li><code>Range</code></li>
       <li><code>Regexp</code></li>
       <li><code>String</code></li>


### PR DESCRIPTION
Added the `Moped::BSON::Binary` field type, which might have [helped this Stack Overflow user](http://stackoverflow.com/questions/13106598/saving-binary-data-using-mongoid-in-rails/13106658) solve their problem.
